### PR TITLE
changed TestClass.cs to MsgBox.cs in TestPayload.csproj

### DIFF
--- a/TestPayload/TestPayload.csproj
+++ b/TestPayload/TestPayload.csproj
@@ -41,7 +41,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="TestClass.cs" />
+    <Compile Include="MsgBox.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Previous commit changed the file TestClass.cs to MsgBox.cs, but it's still referenced by the old filename in TestPayload.csproj. This broke the build process for me.

`1>------ Build started: Project: GadgetToJScript, Configuration: Release Any CPU ------
2>------ Build started: Project: TestPayload, Configuration: Release Any CPU ------
2>CSC : error CS2001: Source file 'C:\Users\...\Desktop\GadgetToJScript-master\TestPayload\TestClass.cs' could not be found.
1>  GadgetToJScript -> C:\Users\...\Desktop\GadgetToJScript-master\GadgetToJScript\bin\Release\GadgetToJScript.exe
========== Build: 1 succeeded, 1 failed, 0 up-to-date, 0 skipped ==========`

